### PR TITLE
Add "must" functions for tersely asserting function success

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -142,7 +142,7 @@ func ErrorIsAll(expected ...error) ErrorCheck {
 //
 // See also Must0, Must2, and Must3 for working with functions of other coarity.
 //
-//	bytes := expect.Must(t)(io.ReadAll(reader))
+//	bytes := expect.Must(io.ReadAll(reader))(t)
 func Must[V any](value V, err error) func(T) V {
 	return func(t T) V {
 		t.Helper()

--- a/errors.go
+++ b/errors.go
@@ -133,3 +133,56 @@ func ErrorIsAll(expected ...error) ErrorCheck {
 		}
 	}
 }
+
+// Must can be used on a (value, error) pair to either get the value or
+// immediately fail the test if the error is non-nil. The T parameter is
+// curried, rather than passed as a third argument, so that (value, error)
+// function return values can be passed to Must directly, without assigning them
+// to intermediate variables.
+//
+// See also Must0, Must2, and Must3 for working with functions of other coarity.
+//
+//	bytes := expect.Must(t)(io.ReadAll(reader))
+func Must[V any](value V, err error) func(T) V {
+	return func(t T) V {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		return value
+	}
+}
+
+// Must0 is similar to Must but for functions returning just an error, without a
+// value.
+func Must0(err error) func(T) {
+	return func(t T) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}
+}
+
+// Must2 is similar to Must but for functions returning two values and an error.
+func Must2[V1 any, V2 any](value1 V1, value2 V2, err error) func(T) (V1, V2) {
+	return func(t T) (V1, V2) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		return value1, value2
+	}
+}
+
+// Must3 is similar to Must but for functions returning three values and an
+// error.
+func Must3[V1 any, V2 any, V3 any](value1 V1, value2 V2, value3 V3, err error) func(T) (V1, V2, V3) {
+	return func(t T) (V1, V2, V3) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		return value1, value2, value3
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -171,6 +171,146 @@ func TestErrors(t *testing.T) {
 	}
 }
 
+func TestMust(t *testing.T) {
+	type testCase struct {
+		f                  func() (bool, error)
+		expectedValue      bool
+		expectedFatalCalls int32
+	}
+	run := func(name string, testCase testCase) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+			tMock := newTMock()
+			value := Must(testCase.f())(tMock)
+			Equal(t, value, testCase.expectedValue)
+			Equal(t, testCase.expectedFatalCalls, tMock.FatalfCalled)
+		})
+	}
+
+	run("Error", testCase{
+		f: func() (bool, error) {
+			return false, ErrTest
+		},
+		expectedValue:      false,
+		expectedFatalCalls: 1,
+	})
+	run("Success", testCase{
+		f: func() (bool, error) {
+			return true, nil
+		},
+		expectedValue:      true,
+		expectedFatalCalls: 0,
+	})
+}
+
+func TestMust0(t *testing.T) {
+	type testCase struct {
+		f                  func() error
+		expectedFatalCalls int32
+	}
+	run := func(name string, testCase testCase) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+			tMock := newTMock()
+			Must0(testCase.f())(tMock)
+			Equal(t, testCase.expectedFatalCalls, tMock.FatalfCalled)
+		})
+	}
+
+	run("Error", testCase{
+		f: func() error {
+			return ErrTest
+		},
+		expectedFatalCalls: 1,
+	})
+	run("Success", testCase{
+		f: func() error {
+			return nil
+		},
+		expectedFatalCalls: 0,
+	})
+}
+
+func TestMust2(t *testing.T) {
+	type testCase struct {
+		f                  func() (bool, bool, error)
+		expectedValue1     bool
+		expectedValue2     bool
+		expectedFatalCalls int32
+	}
+	run := func(name string, testCase testCase) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+			tMock := newTMock()
+			value1, value2 := Must2(testCase.f())(tMock)
+			Equal(t, value1, testCase.expectedValue1)
+			Equal(t, value2, testCase.expectedValue2)
+			Equal(t, testCase.expectedFatalCalls, tMock.FatalfCalled)
+		})
+	}
+
+	run("Error", testCase{
+		f: func() (bool, bool, error) {
+			return false, false, ErrTest
+		},
+		expectedValue1:     false,
+		expectedValue2:     false,
+		expectedFatalCalls: 1,
+	})
+	run("Success", testCase{
+		f: func() (bool, bool, error) {
+			return true, true, nil
+		},
+		expectedValue1:     true,
+		expectedValue2:     true,
+		expectedFatalCalls: 0,
+	})
+}
+
+func TestMust3(t *testing.T) {
+	type testCase struct {
+		f                  func() (bool, bool, bool, error)
+		expectedValue1     bool
+		expectedValue2     bool
+		expectedValue3     bool
+		expectedFatalCalls int32
+	}
+	run := func(name string, testCase testCase) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+			tMock := newTMock()
+			value1, value2, value3 := Must3(testCase.f())(tMock)
+			Equal(t, value1, testCase.expectedValue1)
+			Equal(t, value2, testCase.expectedValue2)
+			Equal(t, value3, testCase.expectedValue3)
+			Equal(t, testCase.expectedFatalCalls, tMock.FatalfCalled)
+		})
+	}
+
+	run("Error", testCase{
+		f: func() (bool, bool, bool, error) {
+			return false, false, false, ErrTest
+		},
+		expectedValue1:     false,
+		expectedValue2:     false,
+		expectedValue3:     false,
+		expectedFatalCalls: 1,
+	})
+	run("Success", testCase{
+		f: func() (bool, bool, bool, error) {
+			return true, true, true, nil
+		},
+		expectedValue1:     true,
+		expectedValue2:     true,
+		expectedValue3:     true,
+		expectedFatalCalls: 0,
+	})
+}
+
 type testErrorA struct{}
 
 func (e testErrorA) Error() string {
@@ -199,5 +339,6 @@ func newTMock() *TMock {
 	return &TMock{
 		HelperStub: func() {},
 		ErrorfStub: func(format string, args ...any) {},
+		FatalfStub: func(format string, args ...any) {},
 	}
 }

--- a/testing.go
+++ b/testing.go
@@ -10,4 +10,5 @@ package expect
 type T interface {
 	Helper()
 	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
 }

--- a/testing_mock.go
+++ b/testing_mock.go
@@ -2,23 +2,34 @@ package expect
 
 import (
 	"sync/atomic"
+	"testing"
 )
 
 // TMock is a mock implementation of the T
 // interface.
 type TMock struct {
+	T            *testing.T
 	HelperStub   func()
 	HelperCalled int32
 	ErrorfStub   func(format string, args ...any)
 	ErrorfCalled int32
+	FatalfStub   func(format string, args ...any)
+	FatalfCalled int32
 }
 
+// Verify that *TMock implements T.
 var _ T = &TMock{}
 
 // Helper is a stub for the T.Helper
 // method that records the number of times it has been called.
 func (m *TMock) Helper() {
 	atomic.AddInt32(&m.HelperCalled, 1)
+	if m.HelperStub == nil {
+		if m.T != nil {
+			m.T.Error("HelperStub is nil")
+		}
+		panic("Helper unimplemented")
+	}
 	m.HelperStub()
 }
 
@@ -26,5 +37,24 @@ func (m *TMock) Helper() {
 // method that records the number of times it has been called.
 func (m *TMock) Errorf(format string, args ...any) {
 	atomic.AddInt32(&m.ErrorfCalled, 1)
+	if m.ErrorfStub == nil {
+		if m.T != nil {
+			m.T.Error("ErrorfStub is nil")
+		}
+		panic("Errorf unimplemented")
+	}
 	m.ErrorfStub(format, args...)
+}
+
+// Fatalf is a stub for the T.Fatalf
+// method that records the number of times it has been called.
+func (m *TMock) Fatalf(format string, args ...any) {
+	atomic.AddInt32(&m.FatalfCalled, 1)
+	if m.FatalfStub == nil {
+		if m.T != nil {
+			m.T.Error("FatalfStub is nil")
+		}
+		panic("Fatalf unimplemented")
+	}
+	m.FatalfStub(format, args...)
 }


### PR DESCRIPTION
### Dependencies

None.

### Documentation

Inspired by test utilities such as [this one](https://github.com/nicheinc/go-common/blob/3072b66efcb04f9768bae24a3e73b270f21ac121/service/middleware/testutils_test.go#L20-L25) in a `go-common` branch.

### Description

This adds a family of three new functions: `Must0`, `Must`, `Must2`, and `Must3` (named in the spirit of the [`iter` types](https://pkg.go.dev/iter)). These functions take some number of values and an error, and return a function that when called with a `*testing.T` either returns the values or fails immediately, if the error is non-`nil`. Currying the `*testing.T` argument allows functions with multiple return values to be invoked directly within the `Must*` call, without assigning them to intermediate values first. The `_must` function these are based on panics, but I think failing using `Fatalf` can produce nicer error messages.

### Versioning

Minor. Note that this contains a small breaking change since I added a method (`Fatalf`) to the `expect.T` interface. However, `expect` is still v0, and looking at how `expect.T` is used in our code, there shouldn't be any breakage anyway.